### PR TITLE
Add become for daemon.json update

### DIFF
--- a/tasks/docker.yml
+++ b/tasks/docker.yml
@@ -8,6 +8,7 @@
     update_cache: yes
 
 - name: Adding docker daemon.json
+  become: yes
   template:
     src: daemon.json.j2
     dest: /etc/docker/daemon.json


### PR DESCRIPTION
The daemon.json update fails, since the /etc/docker file is owned by the root user. This PR adds `become: yes` to make sure that Ansible can update the file. 